### PR TITLE
security fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ ir_receiver-cache.lib
 .vscode
 out
 CMakeSettings.json
-
+CMakeFiles

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ __pycache__
 *.sch-bak
 fp-info-cache
 ir_receiver-cache.lib
+.vs
+.vscode
+out
+CMakeSettings.json
+

--- a/src/ysbitmap/src/ysbitmap.cpp
+++ b/src/ysbitmap/src/ysbitmap.cpp
@@ -116,12 +116,27 @@ YsBitmap YsBitmap::Rotate90L(void) const
 
 YSRESULT YsBitmap::LoadBmp(const char fn[])
 {
-	FILE *fp=fopen(fn,"rb");
+	YSRESULT result;
+	FILE* fp = NULL;
+
+	//attempt to open the file
+	errno_t err = fopen_s(&fp, fn, "rb");
+	if (err != 0)
+	{
+		result = YSERR;
+	}
+
+	//attempt to read the bitmap contents
 	YSRESULT res=LoadBmp(fp);
 	if(NULL!=fp)
 	{
-		fclose(fp);
+		err = fclose(fp);
+		if (err != 0)
+		{
+			result = YSERR;
+		}
 	}
+
 	return res;
 }
 

--- a/src/ysbitmap/src/yspngenc.cpp
+++ b/src/ysbitmap/src/yspngenc.cpp
@@ -1672,11 +1672,13 @@ int YsGenericPngEncoder::WritetEXtChunk(const char keyword[],const char text[])
 		chunk[7]='t';
 
 		unsigned char *dataField=chunk+8;
-		strncpy_s((char*)dataField, nChunk, keyword, nKeyword);
+		long long buffSize = nChunk - 8;
+		strncpy_s((char*)dataField, buffSize, keyword, nKeyword);
 
 		dataField[nKeyword]=0;
 
-		strncpy_s((char*)dataField + nKeyword + 1, nChunk, text, nText);
+		buffSize = buffSize - (nKeyword + 1);
+		strncpy_s((char*)dataField + nKeyword + 1, buffSize, text, nText);
 
 		dataField[nKeyword+1+nText  ]=0;
 		dataField[nKeyword+1+nText+1]=0;

--- a/src/ysbitmap/src/yspngenc.cpp
+++ b/src/ysbitmap/src/yspngenc.cpp
@@ -1672,11 +1672,13 @@ int YsGenericPngEncoder::WritetEXtChunk(const char keyword[],const char text[])
 		chunk[7]='t';
 
 		unsigned char *dataField=chunk+8;
-		strncpy((char *)dataField,keyword,nKeyword);
+		long long buffSize = nChunk - 8;
+		strncpy_s((char*)dataField, buffSize, keyword, nKeyword);
 
 		dataField[nKeyword]=0;
 
-		strncpy((char *)dataField+nKeyword+1,text,nText);
+		buffSize = buffSize - (nKeyword + 1);
+		strncpy_s((char*)dataField + nKeyword + 1, buffSize, text, nText);
 
 		dataField[nKeyword+1+nText  ]=0;
 		dataField[nKeyword+1+nText+1]=0;

--- a/src/ysbitmap/src/yspngenc.cpp
+++ b/src/ysbitmap/src/yspngenc.cpp
@@ -1672,13 +1672,11 @@ int YsGenericPngEncoder::WritetEXtChunk(const char keyword[],const char text[])
 		chunk[7]='t';
 
 		unsigned char *dataField=chunk+8;
-		long long buffSize = nChunk - 8;
-		strncpy_s((char*)dataField, buffSize, keyword, nKeyword);
+		strncpy_s((char*)dataField, nChunk, keyword, nKeyword);
 
 		dataField[nKeyword]=0;
 
-		buffSize = buffSize - (nKeyword + 1);
-		strncpy_s((char*)dataField + nKeyword + 1, buffSize, text, nText);
+		strncpy_s((char*)dataField + nKeyword + 1, nChunk, text, nText);
 
 		dataField[nKeyword+1+nText  ]=0;
 		dataField[nKeyword+1+nText+1]=0;

--- a/src/ysclass/src/ysfilename.cpp
+++ b/src/ysclass/src/ysfilename.cpp
@@ -176,7 +176,9 @@ void YsPutExt(char *fname,const char *ext)
 		ext++;
 	}
 
-	sprintf(fname,"%s.%s",fname,ext);
+	//buffer size: filename length + extension length + 1 for '.'
+	size_t buffLength = strlen(fname) + strlen(ext) + 1;
+	sprintf_s(fname, buffLength, "%s.%s", fname, ext);
 }
 
 unsigned long YsFileSize(const char *fname)

--- a/src/ysclass/src/ysfilename.cpp
+++ b/src/ysclass/src/ysfilename.cpp
@@ -220,7 +220,7 @@ YSRESULT YsSeparatePathFile(char *pth,char *fil,const char *org)
 {
 	char tmp[256],*seekPtr,*cutPtr;
 
-	strcpy(tmp,org);
+	strcpy_s(tmp, 256, org);
 	cutPtr=tmp;
 
 	/* Ysip Drive Name */

--- a/src/ysclass/src/ysfilename.cpp
+++ b/src/ysclass/src/ysfilename.cpp
@@ -276,8 +276,8 @@ void YsReplaceExtension(char fn[],const char ext[])  // ext can be "*.???",".???
 
 	if(fn[0]!=0)
 	{
-		strcat(fn,".");
-		strcat(fn,ext+offset);
+		strcat_s(fn, sizeof(fn), ".");
+		strcat_s(fn, sizeof(fn), ext + offset);
 	}
 }
 

--- a/src/ysclass/src/ysfilename.cpp
+++ b/src/ysclass/src/ysfilename.cpp
@@ -176,8 +176,8 @@ void YsPutExt(char *fname,const char *ext)
 		ext++;
 	}
 
-	//buffer size: filename length + extension length + 1 for '.'
-	size_t buffLength = strlen(fname) + strlen(ext) + 1;
+	//buffer size: filename length + extension length + 1 for '.' + 1 for null terminator
+	size_t buffLength = strlen(fname) + strlen(ext) + 2;
 	sprintf_s(fname, buffLength, "%s.%s", fname, ext);
 }
 

--- a/src/ysclass/src/ysfilename.cpp
+++ b/src/ysclass/src/ysfilename.cpp
@@ -264,7 +264,7 @@ void YsDeleteExtension(char def[])
 }
 
 void YsReplaceExtension(char fn[],const char ext[])  // ext can be "*.???",".???" or "???"
-{
+{	
 	int offset;
 	offset=0;
 	while(ext[offset]=='.' || ext[offset]=='*')
@@ -272,12 +272,15 @@ void YsReplaceExtension(char fn[],const char ext[])  // ext can be "*.???",".???
 		offset++;  // Skip first "*.", if it is given.
 	}
 
+	//buffer size: string length of fn + null terminator
+	unsigned long long buffSize = strlen(fn) + 1;
+
 	YsDeleteExtension(fn);
 
 	if(fn[0]!=0)
 	{
-		strcat_s(fn, sizeof(fn), ".");
-		strcat_s(fn, sizeof(fn), ext + offset);
+		strcat_s(fn, buffSize, ".");
+		strcat_s(fn, buffSize, ext + offset);
 	}
 }
 

--- a/src/ysclass/src/ysprintf.cpp
+++ b/src/ysclass/src/ysprintf.cpp
@@ -58,7 +58,7 @@ YsPrintf::YsPrintf(const char *fmt,...)
 	va_list arg_ptr;
 
 	va_start(arg_ptr,fmt);
-	a=vsprintf(buf,fmt,arg_ptr);
+	a=vsprintf_s(buf, 4096, fmt,arg_ptr);
 	va_end(arg_ptr);
 
 	if(def!=NULL)

--- a/src/ysport/src/windows/yswin32fileio.cpp
+++ b/src/ysport/src/windows/yswin32fileio.cpp
@@ -88,6 +88,8 @@ FILE *YsFileIO::Fopen(const wchar_t fn[],const char mode[])
 	FILE* stream;
 	YsWString wmode;
 	wmode.SetUTF8String(mode);
+
+	_set_errno(0);
 	errno_t err = _wfopen_s(&stream, fn, wmode);
 
 	if (err == 0)

--- a/src/ysport/src/windows/yswin32fileio.cpp
+++ b/src/ysport/src/windows/yswin32fileio.cpp
@@ -85,9 +85,16 @@ YSRESULT YsFileIO::MkDir(const wchar_t dirName[])
 
 FILE *YsFileIO::Fopen(const wchar_t fn[],const char mode[])
 {
+	FILE* stream;
 	YsWString wmode;
 	wmode.SetUTF8String(mode);
-	return _wfopen(fn,wmode);
+	errno_t err = _wfopen_s(&stream, fn, wmode);
+
+	if (err == 0)
+	{
+		return stream;
+	}
+	return NULL;
 }
 
 FILE *YsFileIO::Fopen(const char fn[],const char mode[])

--- a/tests/batch/CMakeLists.txt
+++ b/tests/batch/CMakeLists.txt
@@ -51,5 +51,7 @@ add_subdirectory(ysgebl/kernelutil/YsShellExt_FindNearestPolygon)
 
 add_subdirectory(ysglcpp/arrowUtil)
 
+add_subdirectory(ysport/windows)
+
 
 set(YS_ALL_BATCH_TEST ${YS_ALL_BATCH_TEST} PARENT_SCOPE)

--- a/tests/batch/CMakeLists.txt
+++ b/tests/batch/CMakeLists.txt
@@ -38,6 +38,7 @@ add_subdirectory(ysclass/YsPositiveAreaCalculator)
 add_subdirectory(ysclass/YsFindLeastSquarePoint)
 add_subdirectory(ysclass/YsCommandLine)
 add_subdirectory(ysclass/YsFilename)
+add_subdirectory(ysclass/YsPrintf)
 
 add_subdirectory(ysclass11/YsParallelMergeSort)
 add_subdirectory(ysclass11/YsThreadPool)

--- a/tests/batch/CMakeLists.txt
+++ b/tests/batch/CMakeLists.txt
@@ -37,6 +37,7 @@ add_subdirectory(ysclass/YsPositiveVolumeCalculator)
 add_subdirectory(ysclass/YsPositiveAreaCalculator)
 add_subdirectory(ysclass/YsFindLeastSquarePoint)
 add_subdirectory(ysclass/YsCommandLine)
+add_subdirectory(ysclass/YsFilename)
 
 add_subdirectory(ysclass11/YsParallelMergeSort)
 add_subdirectory(ysclass11/YsThreadPool)

--- a/tests/batch/ysclass/YsFilename/CMakeLists.txt
+++ b/tests/batch/ysclass/YsFilename/CMakeLists.txt
@@ -1,0 +1,370 @@
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(BITNESS 64)
+else()
+	set(BITNESS 32)
+endif()
+
+set(TARGET_NAME "test_batch_ysclass_YsFilename")
+set(IS_LIBRARY_PROJECT 0)
+set(LIB_DEPENDENCY ysclass ysport)
+set(INCLUDE_DEPENDENCY "")
+set(OWN_HEADER_PATH .)
+set(ADDITIONAL_HEADER_PATH)
+set(SINGLE_TARGET 1)
+set(SUB_FOLDER "TESTS_BATCH/ysclass")
+set(LIB_OPTION STATIC)
+set(VERBOSE_MODE 0)
+set(EXE_COPY_DIR "")
+set(WIN_SUBSYSTEM CONSOLE)
+set(EXE_TYPE "")                # Can be "" or MACOSX_BUNDLE
+set(EXCLUDE_IN_UNIVERSAL_WINDOWS 0) # Setting 1 will exclude the project in Universal Windows Platform
+
+list(APPEND YS_ALL_BATCH_TEST ${TARGET_NAME})
+set(YS_ALL_BATCH_TEST ${YS_ALL_BATCH_TEST} PARENT_SCOPE)
+
+
+set(DATA_FILE_LOCATION)
+# If DATA_FILE_LOCATION is set, files and directories under DATA_FILE_LOCATION will be copied to DATA_COPY_DIR.
+# For example, if DATA_FILE_LOCATION is ${CMAKE_SOURCE_DIR}/runtime, and the directory structure under this directory is:
+#    ${CMAKE_SOURCE_DIR}/runtime
+#      language
+#        ja.uitxt
+#        en.uitxt
+#      image1.png
+# then, the destination directory structure will look like:
+#    ${DATA_COPY_DIR}
+#      language
+#        ja.uitxt
+#        en.uitxt
+#      image1.png
+# It is not like directory "runtime" is copied under ${DATA_COPY_DIR}.
+
+
+
+
+#YSBEGIN "CMake Header" Ver 20170110
+# YS CMakeLists Template
+# Copyright (c) 2015 Soji Yamakawa.  All rights reserved.
+# http://www.ysflight.com
+# 
+# Redistribution and use in source and binary forms, with or without modification, 
+# are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, 
+#    this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, 
+#    this list of conditions and the following disclaimer in the documentation 
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 3.0.0)
+if("${CMAKE_CURRENT_SOURCE_DIR}" MATCHES "^${CMAKE_SOURCE_DIR}" AND
+   "${CMAKE_BINARY_DIR}" MATCHES "^${CMAKE_SOURCE_DIR}")
+	message(FATAL_ERROR "In-source build prohibited.\nClear cache and Start cmake from somewhere else.")
+	# First condition is to allow inclusion of the project from outside CMake project with
+	# explicit binary-directory specification.   eg. add_subdirectory from Android CMakeLists.txt
+endif()
+
+if(MSVC)
+	if(NOT WIN_SUBSYSTEM)
+		set(WIN_SUBSYSTEM CONSOLE)
+	endif()
+
+	if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+		if(EXCLUDE_IN_UNIVERSAL_WINDOWS EQUAL 1)
+			return()
+		endif()
+
+		add_definitions(-DYS_IS_UNIVERSAL_WINDOWS_APP)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZW")
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /ZW")
+	endif()
+
+	# I want to keep compatibility with older operating systems, but it's getting difficult.
+	# I have to comment out the following lines.
+	# if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	# 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:${WIN_SUBSYSTEM},5.02 /MACHINE:x64")
+	# else()
+	# 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:${WIN_SUBSYSTEM},5.01 /MACHINE:X86")
+	# endif()
+endif()
+
+if(NOT DEFINED TARGET_NAME)
+	message(FATAL_ERROR "TARGET_NAME not defined.")
+endif()
+if(NOT DEFINED IS_LIBRARY_PROJECT)
+	message(FATAL_ERROR "IS_LIBRARY_PROJECT not defined.")
+endif()
+if(NOT DEFINED SINGLE_TARGET)
+	message(FATAL_ERROR "SINGLE_TARGET not defined.")
+endif()
+
+# 2016/09/22 Learned a better way than specifying -std=c++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(MSVC)
+	# 2016/07/22
+	#  /MT flags should be set outside the public repository.  It is moved to the higher-level CMakeLists.txt
+elseif(APPLE)
+	# 2015/07/15
+	#   Sorry.  I pulled the plug.  All of my programs, including YS FLIGHT SIMULATOR, won't support 
+	#   OSX 10.6 after today.  Apple deliberately disabled C++11 features in the libraries that I need to make my 
+	#	programs compatible with OSX 10.6.
+	#
+	#	I know OSX 10.9 is evil for older models.  My 2008 MacBook Pro flies with OSX 10.6, but becoes
+	#	a sloth with OSX 10.9.  Apple used to be a challenger pursuing Microsoft, but it is now an empire
+	#	that Microsoft once was, and is doing everything that Microsoft did.  Apple inprison programmers
+	#	with Apple-only programming language called Swift (already doing with Objective-C though) and Apple-only
+	#	graphics toolkit called Metal, just as Microsoft did with C# and Direct3D.  Apple is making operating
+	#	system heavier, slower, and inefficient, just as Microsoft has been doing.  The same thing is going all 
+	#	around again.
+	#
+	#	OK, I warn you.  If you are investing your precious time for learning Swift and/or Metal, you are 
+	#	taking a very big gamble.  Apple will throw it away when they get bored of it.  Learning one programming 
+	#	language is not just understanding syntax.  You need to write considerable amount of code to learn the 
+	#	best practices.  So far, C and C++ have been with for more than 20 years.  Will Swift live that long?
+	#	Nobody knows.  I doubt it.  Swift is developed by a closed group.  Maybe one genius is in charge now.
+	#	But, when the genius leaves, it could cramble down.  C and C++ are developed by the top computer
+	#	scientists of the world.  To me, which is superior is obvious.
+	#
+	#	No user wants a new operating system.  Everyone wants their system to be cleaner, more stable, more 
+	#	secure, and more resource-efficient.  Neither Apple nor Microsoft gets it.  We continue to be forced
+	#	to throw away perfectly healthy hardware, and buy new over-spec hardware, which is inefficiently
+	#	operated by the wasteful operating systems.
+	#
+	#	Sad and outrageous.  But, that's what Apple do.  Apple takes C++11 hostage and forces programmers 
+	#	to drop support for older but still active-duty operating systems.
+	#
+	#	Mac is a good computer though.  I am happy with my 2011 MacMini.  I probably would be happy with
+	#	my 2008 MacBook Pro if I still can (practically) use it with OSX 10.6, or if 10.9 is as efficient 
+	#	as 10.6.
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9 -Wno-switch")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=10.9 -Wno-switch")
+elseif(UNIX)
+	# -Wl,--no-as-needed required for g++ 4.8.4 Confirmed unnecessary with 5.4.0
+	#  http://stackoverflow.com/questions/19463602/compiling-multithread-code-with-g
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,--no-as-needed")
+else()
+endif()
+
+if(IS_LIBRARY_PROJECT)
+	#set(YS_LIBRARY_LIST ${YS_LIBRARY_LIST} ${TARGET_NAME} PARENT_SCOPE)
+	# Modified as suggested in CMake performance tips.
+	list(APPEND YS_LIBRARY_LIST ${TARGET_NAME})
+	set(YS_LIBRARY_LIST ${YS_LIBRARY_LIST} PARENT_SCOPE)
+endif()
+
+#YSEND
+
+
+
+if(MSVC)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+elseif(APPLE)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+elseif(UNIX)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+else()
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+endif()
+
+
+
+set(SRCS
+${platform_SRCS}
+test.cpp
+)
+
+set(HEADERS
+${platform_HEADERS}
+)
+
+
+
+#YSBEGIN "CMake Footer" Ver 20170110
+if(YS_CXX_FLAGS)
+	foreach(SRC ${SRCS})
+		if(${SRC} MATCHES .cpp$)
+			set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/${SRC} PROPERTIES COMPILE_FLAGS "${YS_CXX_FLAGS}")
+		endif()
+	endforeach(SRC)
+endif()
+
+# When template sources are unavoidable >>
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore" AND NOT IS_LIBRARY_PROJECT)
+	get_property(XAML_TEMPLATE_DIR TARGET fslazywindow PROPERTY FS_XAML_TEMPLATE_DIR)
+	get_property(XAML_ASSET_FILES TARGET fslazywindow PROPERTY FS_XAML_ASSET_FILES)
+	get_property(XAML_APP_DEF_SOURCE TARGET fslazywindow PROPERTY FS_XAML_APP_DEF_SOURCE)
+	get_property(XAML_CLATTER_SOURCE TARGET fslazywindow PROPERTY FS_XAML_CLATTER_SOURCE)
+	get_property(XAML_PER_PROJ_SOURCE TARGET fslazywindow PROPERTY FS_XAML_PER_PROJ_SOURCE)
+	foreach(SRC ${XAML_PER_PROJ_SOURCE})
+		file(COPY ${XAML_TEMPLATE_DIR}/${SRC} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+		list(APPEND COPIED_XAML_PER_PROJ_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/${SRC})
+	endforeach(SRC)
+	list(APPEND SRCS ${XAML_APP_DEF_SOURCE} ${XAML_CLATTER_SOURCE} ${COPIED_XAML_PER_PROJ_SOURCE} ${XAML_ASSET_FILES})
+	include_directories(${XAML_TEMPLATE_DIR})
+	set_source_files_properties(${XAML_ASSET_FILES} PROPERTIES VS_DEPLOYMENT_CONTENT 1)
+	set_source_files_properties(${XAML_ASSET_FILES} PROPERTIES VS_DEPLOYMENT_LOCATION "Assets")
+	set_source_files_properties(${XAML_APP_DEF_SOURCE} PROPERTIES VS_XAML_TYPE ApplicationDefinition)
+endif()
+# When template sources are unavoidable <<
+
+foreach(ONE_TARGET ${TARGET_NAME})
+	message([${ONE_TARGET}])
+
+	if(SINGLE_TARGET)
+		if(NOT IS_LIBRARY_PROJECT)
+			add_executable(${ONE_TARGET} ${EXE_TYPE} ${SRCS} ${HEADERS})
+		else()
+			add_library(${ONE_TARGET} ${LIB_OPTION} ${SRCS} ${HEADERS})
+		endif()
+	endif()
+
+	if(NOT IS_LIBRARY_PROJECT)
+		if(EXE_COPY_DIR)
+			# 2015/02/01 CMAKE_CONFIGURATION_TYPES may be empty.
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${EXE_COPY_DIR}")
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${EXE_COPY_DIR}")
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${EXE_COPY_DIR}")
+			foreach(CFGTYPE ${CMAKE_CONFIGURATION_TYPES})
+				string(TOUPPER ${CFGTYPE} UCFGTYPE)
+				set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${UCFGTYPE} "${EXE_COPY_DIR}")
+			endforeach(CFGTYPE)
+		endif()
+	else()
+		set(INHERITING_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ${OWN_HEADER_PATH} ${ADDITIONAL_HEADER_PATH})
+
+		foreach(DEPEND_TARGET ${INCLUDE_DEPENDENCY})
+			get_property(TARGET_INCLUDE_DIR TARGET ${DEPEND_TARGET} PROPERTY INCLUDE_DIRECTORIES)
+			list(APPEND INHERITING_INCLUDE_DIR ${TARGET_INCLUDE_DIR})
+		endforeach(DEPEND_TARGET)
+
+		list(REMOVE_DUPLICATES INHERITING_INCLUDE_DIR)
+		target_include_directories(${ONE_TARGET} PUBLIC ${INHERITING_INCLUDE_DIR})
+
+		if(VERBOSE_MODE)
+			message("Inheriting include directories ${INHERITING_INCLUDE_DIR}")
+		endif()
+	endif()
+
+	set(${ONE_TARGET}_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}" PARENT_SCOPE)
+
+	if(SUB_FOLDER)
+		if(VERBOSE_MODE)
+			message("Putting in folder ${SUB_FOLDER}")
+		endif()
+		set_property(TARGET ${ONE_TARGET} PROPERTY FOLDER ${SUB_FOLDER})
+	endif()
+
+	if(VERBOSE_MODE)
+		foreach(LINKLIB ${LIB_DEPENDENCY})
+			message(Lib=${LINKLIB})
+		endforeach(LINKLIB)
+	endif()
+	target_link_libraries(${ONE_TARGET} ${LIB_DEPENDENCY})
+
+	# We suffered enough from the shared stdc++
+	if(UNIX AND NOT APPLE AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+		target_link_libraries(${ONE_TARGET} pthread -static-libstdc++ -static-libgcc)
+	endif()
+
+	if(ADDITIONAL_HEADER_PATH)
+		if(VERBOSE_MODE)
+			message(Additional Include=${ADDITIONAL_HEADER_PATH})
+		endif()
+		include_directories(${ADDITIONAL_HEADER_PATH})
+	endif()
+endforeach(ONE_TARGET)
+
+if(DATA_FILE_LOCATION)
+	foreach(ONE_DATA_FILE_LOCATION ${DATA_FILE_LOCATION})
+		foreach(ONE_TARGET ${TARGET_NAME})
+			get_property(IS_MACOSX_BUNDLE TARGET ${ONE_TARGET} PROPERTY MACOSX_BUNDLE)
+
+			if(DATA_COPY_DIR)
+				set(DATA_DESTINATION ${DATA_COPY_DIR})
+			else()
+				if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+					if(NOT YS_ANDROID_ASSET_DIRECTORY)
+						MESSAGE(FATAL_ERROR "YS_ANDROID_ASSET_DIRECTORY not defined or empty.")
+					endif()
+					set(DATA_DESTINATION ${YS_ANDROID_ASSET_DIRECTORY})
+				elseif(NOT EXE_COPY_DIR)
+					if(APPLE AND IS_MACOSX_BUNDLE)
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>/../Resources")
+					elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>/Assets")
+					elseif(MSVC)
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>")
+					else()
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>")
+					endif()
+				else()
+					if(IS_MACOSX_BUNDLE)
+						set(DATA_DESTINATION "${EXE_COPY_DIR}/${ONE_TARGET}.app/Contents/Resources")
+					elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+						set(DATA_DESTINATION "${EXE_COPY_DIR}/Assets")
+					else()
+						set(DATA_DESTINATION "${EXE_COPY_DIR}")
+					endif()
+				endif()
+			endif()
+
+			# 2016/02/13 Use of generator-expression causes / be used in the DATA_DESTINATION
+			#            What's worse is it is not replaced with \\ by REGEX because it
+			#            is expanded at build time, not cmake time.
+			#if(MSVC)
+			#	string(REGEX REPLACE "/" "\\\\" WIN_ONE_DATA_FILE_LOCATION "${ONE_DATA_FILE_LOCATION}")
+			#	string(REGEX REPLACE "/" "\\\\" WIN_DATA_DESTINATION "${DATA_DESTINATION}")
+			#	add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+			#		COMMAND echo [File Copy]
+			#		COMMAND echo From: "${WIN_ONE_DATA_FILE_LOCATION}\\*"
+			#		COMMAND echo To:   "${WIN_DATA_DESTINATION}\\."
+			#		COMMAND xcopy "${WIN_ONE_DATA_FILE_LOCATION}\\*" "${WIN_DATA_DESTINATION}\\." /E /D /C /Y
+			#	)
+			#else()
+			#	add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+			#		COMMAND echo [File Copy]
+			#		COMMAND echo From: "${ONE_DATA_FILE_LOCATION}"
+			#		COMMAND echo To:   "${DATA_DESTINATION}"
+			#		COMMAND mkdir -p "${DATA_DESTINATION}"
+			#		COMMAND rsync -r "${ONE_DATA_FILE_LOCATION}/*" "${DATA_DESTINATION}"
+			#	)
+			#endif()
+
+			# "cmake -E copy_directory" does the job in any cmake-supporting platforms, but what if the command-line cmake is not installed like MacOSX App?
+			# 2016/02/13  Probably using ${CMAKE_COMMAND} is the solution.
+			set_property(TARGET ${ONE_TARGET} PROPERTY YS_DATA_COPY_DIR "${DATA_DESTINATION}")
+			add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+				COMMAND echo For:  ${ONE_TARGET}
+				COMMAND echo Copy
+				COMMAND echo From: ${ONE_DATA_FILE_LOCATION}
+				COMMAND echo To:   ${DATA_DESTINATION}
+				COMMAND "${CMAKE_COMMAND}" -E make_directory \"${DATA_DESTINATION}\"
+				COMMAND "${CMAKE_COMMAND}" -E copy_directory \"${ONE_DATA_FILE_LOCATION}\" \"${DATA_DESTINATION}\")
+
+		endforeach(ONE_TARGET)
+	endforeach(ONE_DATA_FILE_LOCATION)
+endif()
+
+#YSEND
+
+add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})

--- a/tests/batch/ysclass/YsFilename/test.cpp
+++ b/tests/batch/ysclass/YsFilename/test.cpp
@@ -30,7 +30,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ysclass.h>
 
 //test scenario: replace filename extension with separator ('.') included
-YSRESULT YsFilename_ReplaceExtensionSeparatorIncludedTest(void)
+YSRESULT YsFilename_YsReplaceExtension_SeparatorIncludedTest(void)
 {
 	char filename[] = "filename.txt";
 	char replaceExt[] = ".xyz";
@@ -45,11 +45,12 @@ YSRESULT YsFilename_ReplaceExtensionSeparatorIncludedTest(void)
 }
 
 //test scenario: replace filename extension without separator ('.') included
-YSRESULT YsFilename_ReplaceExtensionSeparatorNotIncludedTest(void)
+YSRESULT YsFilename_YsReplaceExtension_SeparatorNotIncludedTest(void)
 {
 	char filename[] = "filename.txt";
 	char replaceExt[] = "xyz";
 	char filenameExpected[] = "filename.xyz";
+
 	YsReplaceExtension(filename, replaceExt);
 
 	if (strcmp(filename, filenameExpected) != 0)
@@ -59,15 +60,61 @@ YSRESULT YsFilename_ReplaceExtensionSeparatorNotIncludedTest(void)
 	return YSOK;
 }
 
+//test scenario: separate filename from path with windows path separators ('\')
+YSRESULT YsFilename_YsSeparatePathFileTest_UsingWindowsPathSeparators(void)
+{
+	char org[] = "C:\\Users\\Soji\\Documents\\somefile.txt";
+	char path[256];
+	char filename[256];
+	char pathExpected[] = "C:\\Users\\Soji\\Documents\\";
+	char filenameExpected[] = "somefile.txt";
+
+	YsSeparatePathFile(path, filename, org);
+
+	if (strcmp(filename, filenameExpected) != 0 || strcmp(path, pathExpected) != 0)
+	{
+		return YSERR;
+	}
+	return YSOK;
+}
+
+//test scenario: separate filename from path with unix path separators ('/')
+YSRESULT YsFilename_YsSeparatePathFileTest_UsingUnixPathSeparators(void)
+{
+	char org[] = "C:/Users/Soji/Documents/somefile.txt";
+	char path[256];
+	char filename[256];
+	char pathExpected[] = "C:/Users/Soji/Documents/";
+	char filenameExpected[] = "somefile.txt";
+
+	YsSeparatePathFile(path, filename, org);
+
+	if (strcmp(filename, filenameExpected) != 0 || strcmp(path, pathExpected) != 0)
+	{
+		return YSERR;
+	}
+	return YSOK;
+}
+
 int main(void)
 {
 	int nFail = 0;
-	if (YSOK != YsFilename_ReplaceExtensionSeparatorIncludedTest())
+	if (YSOK != YsFilename_YsReplaceExtension_SeparatorIncludedTest())
 	{
 		++nFail;
 	}
 
-	if (YSOK != YsFilename_ReplaceExtensionSeparatorNotIncludedTest())
+	if (YSOK != YsFilename_YsReplaceExtension_SeparatorNotIncludedTest())
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFilename_YsSeparatePathFileTest_UsingWindowsPathSeparators())
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFilename_YsSeparatePathFileTest_UsingUnixPathSeparators())
 	{
 		++nFail;
 	}

--- a/tests/batch/ysclass/YsFilename/test.cpp
+++ b/tests/batch/ysclass/YsFilename/test.cpp
@@ -29,6 +29,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ysclass.h>
 
+//test scenario: replace filename extension with separator ('.') included
 YSRESULT YsFilename_ReplaceExtensionSeparatorIncludedTest(void)
 {
 	char filename[] = "filename.txt";
@@ -43,6 +44,7 @@ YSRESULT YsFilename_ReplaceExtensionSeparatorIncludedTest(void)
 	return YSOK;
 }
 
+//test scenario: replace filename extension without separator ('.') included
 YSRESULT YsFilename_ReplaceExtensionSeparatorNotIncludedTest(void)
 {
 	char filename[] = "filename.txt";

--- a/tests/batch/ysclass/YsFilename/test.cpp
+++ b/tests/batch/ysclass/YsFilename/test.cpp
@@ -96,6 +96,38 @@ YSRESULT YsFilename_YsSeparatePathFileTest_UsingUnixPathSeparators(void)
 	return YSOK;
 }
 
+//test scenario: append extension to filename with separator ('.') included
+YSRESULT YsFilename_YsPutExt_SeparatorIncludedTest(void)
+{
+	char filename[64] = "filename";
+	char ext[] = ".txt";
+	char filenameExpected[] = "filename.txt";
+
+	YsPutExt(filename, ext);
+
+	if (strcmp(filename, filenameExpected) != 0)
+	{
+		return YSERR;
+	}
+	return YSOK;
+}
+
+//test scenario: append extension to filename without separator ('.') included
+YSRESULT YsFilename_YsPutExt_SeparatorNotIncludedTest(void)
+{
+	char filename[64] = "filename";
+	char ext[] = "txt";
+	char filenameExpected[] = "filename.txt";
+
+	YsPutExt(filename, ext);
+
+	if (strcmp(filename, filenameExpected) != 0)
+	{
+		return YSERR;
+	}
+	return YSOK;
+}
+
 int main(void)
 {
 	int nFail = 0;
@@ -115,6 +147,16 @@ int main(void)
 	}
 
 	if (YSOK != YsFilename_YsSeparatePathFileTest_UsingUnixPathSeparators())
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFilename_YsPutExt_SeparatorIncludedTest())
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFilename_YsPutExt_SeparatorNotIncludedTest())
 	{
 		++nFail;
 	}

--- a/tests/batch/ysclass/YsFilename/test.cpp
+++ b/tests/batch/ysclass/YsFilename/test.cpp
@@ -1,0 +1,79 @@
+/* ////////////////////////////////////////////////////////////
+
+File Name: test.cpp
+Copyright (c) 2017 Soji Yamakawa.  All rights reserved.
+http://www.ysflight.com
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//////////////////////////////////////////////////////////// */
+
+#include <ysclass.h>
+
+YSRESULT YsFilename_ReplaceExtensionSeparatorIncludedTest(void)
+{
+	char filename[] = "filename.txt";
+	char replaceExt[] = ".xyz";
+	char filenameExpected[] = "filename.xyz";
+	YsReplaceExtension(filename, replaceExt);
+
+	if (strcmp(filename, filenameExpected) != 0)
+	{
+		return YSERR;
+	}
+	return YSOK;
+}
+
+YSRESULT YsFilename_ReplaceExtensionSeparatorNotIncludedTest(void)
+{
+	char filename[] = "filename.txt";
+	char replaceExt[] = "xyz";
+	char filenameExpected[] = "filename.xyz";
+	YsReplaceExtension(filename, replaceExt);
+
+	if (strcmp(filename, filenameExpected) != 0)
+	{
+		return YSERR;
+	}
+	return YSOK;
+}
+
+int main(void)
+{
+	int nFail = 0;
+	if (YSOK != YsFilename_ReplaceExtensionSeparatorIncludedTest())
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFilename_ReplaceExtensionSeparatorNotIncludedTest())
+	{
+		++nFail;
+	}
+
+	printf("%d failed.\n", nFail);
+	if (0 < nFail)
+	{
+		return 1;
+	}
+	return 0;
+}

--- a/tests/batch/ysclass/YsPrintf/CMakeLists.txt
+++ b/tests/batch/ysclass/YsPrintf/CMakeLists.txt
@@ -1,0 +1,370 @@
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(BITNESS 64)
+else()
+	set(BITNESS 32)
+endif()
+
+set(TARGET_NAME "test_batch_ysclass_ysprintf")
+set(IS_LIBRARY_PROJECT 0)
+set(LIB_DEPENDENCY ysclass ysport)
+set(INCLUDE_DEPENDENCY "")
+set(OWN_HEADER_PATH .)
+set(ADDITIONAL_HEADER_PATH)
+set(SINGLE_TARGET 1)
+set(SUB_FOLDER "TESTS_BATCH/ysclass")
+set(LIB_OPTION STATIC)
+set(VERBOSE_MODE 0)
+set(EXE_COPY_DIR "")
+set(WIN_SUBSYSTEM CONSOLE)
+set(EXE_TYPE "")                # Can be "" or MACOSX_BUNDLE
+set(EXCLUDE_IN_UNIVERSAL_WINDOWS 0) # Setting 1 will exclude the project in Universal Windows Platform
+
+list(APPEND YS_ALL_BATCH_TEST ${TARGET_NAME})
+set(YS_ALL_BATCH_TEST ${YS_ALL_BATCH_TEST} PARENT_SCOPE)
+
+
+set(DATA_FILE_LOCATION)
+# If DATA_FILE_LOCATION is set, files and directories under DATA_FILE_LOCATION will be copied to DATA_COPY_DIR.
+# For example, if DATA_FILE_LOCATION is ${CMAKE_SOURCE_DIR}/runtime, and the directory structure under this directory is:
+#    ${CMAKE_SOURCE_DIR}/runtime
+#      language
+#        ja.uitxt
+#        en.uitxt
+#      image1.png
+# then, the destination directory structure will look like:
+#    ${DATA_COPY_DIR}
+#      language
+#        ja.uitxt
+#        en.uitxt
+#      image1.png
+# It is not like directory "runtime" is copied under ${DATA_COPY_DIR}.
+
+
+
+
+#YSBEGIN "CMake Header" Ver 20170110
+# YS CMakeLists Template
+# Copyright (c) 2015 Soji Yamakawa.  All rights reserved.
+# http://www.ysflight.com
+# 
+# Redistribution and use in source and binary forms, with or without modification, 
+# are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, 
+#    this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, 
+#    this list of conditions and the following disclaimer in the documentation 
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 3.0.0)
+if("${CMAKE_CURRENT_SOURCE_DIR}" MATCHES "^${CMAKE_SOURCE_DIR}" AND
+   "${CMAKE_BINARY_DIR}" MATCHES "^${CMAKE_SOURCE_DIR}")
+	message(FATAL_ERROR "In-source build prohibited.\nClear cache and Start cmake from somewhere else.")
+	# First condition is to allow inclusion of the project from outside CMake project with
+	# explicit binary-directory specification.   eg. add_subdirectory from Android CMakeLists.txt
+endif()
+
+if(MSVC)
+	if(NOT WIN_SUBSYSTEM)
+		set(WIN_SUBSYSTEM CONSOLE)
+	endif()
+
+	if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+		if(EXCLUDE_IN_UNIVERSAL_WINDOWS EQUAL 1)
+			return()
+		endif()
+
+		add_definitions(-DYS_IS_UNIVERSAL_WINDOWS_APP)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZW")
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /ZW")
+	endif()
+
+	# I want to keep compatibility with older operating systems, but it's getting difficult.
+	# I have to comment out the following lines.
+	# if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	# 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:${WIN_SUBSYSTEM},5.02 /MACHINE:x64")
+	# else()
+	# 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:${WIN_SUBSYSTEM},5.01 /MACHINE:X86")
+	# endif()
+endif()
+
+if(NOT DEFINED TARGET_NAME)
+	message(FATAL_ERROR "TARGET_NAME not defined.")
+endif()
+if(NOT DEFINED IS_LIBRARY_PROJECT)
+	message(FATAL_ERROR "IS_LIBRARY_PROJECT not defined.")
+endif()
+if(NOT DEFINED SINGLE_TARGET)
+	message(FATAL_ERROR "SINGLE_TARGET not defined.")
+endif()
+
+# 2016/09/22 Learned a better way than specifying -std=c++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(MSVC)
+	# 2016/07/22
+	#  /MT flags should be set outside the public repository.  It is moved to the higher-level CMakeLists.txt
+elseif(APPLE)
+	# 2015/07/15
+	#   Sorry.  I pulled the plug.  All of my programs, including YS FLIGHT SIMULATOR, won't support 
+	#   OSX 10.6 after today.  Apple deliberately disabled C++11 features in the libraries that I need to make my 
+	#	programs compatible with OSX 10.6.
+	#
+	#	I know OSX 10.9 is evil for older models.  My 2008 MacBook Pro flies with OSX 10.6, but becoes
+	#	a sloth with OSX 10.9.  Apple used to be a challenger pursuing Microsoft, but it is now an empire
+	#	that Microsoft once was, and is doing everything that Microsoft did.  Apple inprison programmers
+	#	with Apple-only programming language called Swift (already doing with Objective-C though) and Apple-only
+	#	graphics toolkit called Metal, just as Microsoft did with C# and Direct3D.  Apple is making operating
+	#	system heavier, slower, and inefficient, just as Microsoft has been doing.  The same thing is going all 
+	#	around again.
+	#
+	#	OK, I warn you.  If you are investing your precious time for learning Swift and/or Metal, you are 
+	#	taking a very big gamble.  Apple will throw it away when they get bored of it.  Learning one programming 
+	#	language is not just understanding syntax.  You need to write considerable amount of code to learn the 
+	#	best practices.  So far, C and C++ have been with for more than 20 years.  Will Swift live that long?
+	#	Nobody knows.  I doubt it.  Swift is developed by a closed group.  Maybe one genius is in charge now.
+	#	But, when the genius leaves, it could cramble down.  C and C++ are developed by the top computer
+	#	scientists of the world.  To me, which is superior is obvious.
+	#
+	#	No user wants a new operating system.  Everyone wants their system to be cleaner, more stable, more 
+	#	secure, and more resource-efficient.  Neither Apple nor Microsoft gets it.  We continue to be forced
+	#	to throw away perfectly healthy hardware, and buy new over-spec hardware, which is inefficiently
+	#	operated by the wasteful operating systems.
+	#
+	#	Sad and outrageous.  But, that's what Apple do.  Apple takes C++11 hostage and forces programmers 
+	#	to drop support for older but still active-duty operating systems.
+	#
+	#	Mac is a good computer though.  I am happy with my 2011 MacMini.  I probably would be happy with
+	#	my 2008 MacBook Pro if I still can (practically) use it with OSX 10.6, or if 10.9 is as efficient 
+	#	as 10.6.
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9 -Wno-switch")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=10.9 -Wno-switch")
+elseif(UNIX)
+	# -Wl,--no-as-needed required for g++ 4.8.4 Confirmed unnecessary with 5.4.0
+	#  http://stackoverflow.com/questions/19463602/compiling-multithread-code-with-g
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,--no-as-needed")
+else()
+endif()
+
+if(IS_LIBRARY_PROJECT)
+	#set(YS_LIBRARY_LIST ${YS_LIBRARY_LIST} ${TARGET_NAME} PARENT_SCOPE)
+	# Modified as suggested in CMake performance tips.
+	list(APPEND YS_LIBRARY_LIST ${TARGET_NAME})
+	set(YS_LIBRARY_LIST ${YS_LIBRARY_LIST} PARENT_SCOPE)
+endif()
+
+#YSEND
+
+
+
+if(MSVC)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+elseif(APPLE)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+elseif(UNIX)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+else()
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+endif()
+
+
+
+set(SRCS
+${platform_SRCS}
+test.cpp
+)
+
+set(HEADERS
+${platform_HEADERS}
+)
+
+
+
+#YSBEGIN "CMake Footer" Ver 20170110
+if(YS_CXX_FLAGS)
+	foreach(SRC ${SRCS})
+		if(${SRC} MATCHES .cpp$)
+			set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/${SRC} PROPERTIES COMPILE_FLAGS "${YS_CXX_FLAGS}")
+		endif()
+	endforeach(SRC)
+endif()
+
+# When template sources are unavoidable >>
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore" AND NOT IS_LIBRARY_PROJECT)
+	get_property(XAML_TEMPLATE_DIR TARGET fslazywindow PROPERTY FS_XAML_TEMPLATE_DIR)
+	get_property(XAML_ASSET_FILES TARGET fslazywindow PROPERTY FS_XAML_ASSET_FILES)
+	get_property(XAML_APP_DEF_SOURCE TARGET fslazywindow PROPERTY FS_XAML_APP_DEF_SOURCE)
+	get_property(XAML_CLATTER_SOURCE TARGET fslazywindow PROPERTY FS_XAML_CLATTER_SOURCE)
+	get_property(XAML_PER_PROJ_SOURCE TARGET fslazywindow PROPERTY FS_XAML_PER_PROJ_SOURCE)
+	foreach(SRC ${XAML_PER_PROJ_SOURCE})
+		file(COPY ${XAML_TEMPLATE_DIR}/${SRC} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+		list(APPEND COPIED_XAML_PER_PROJ_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/${SRC})
+	endforeach(SRC)
+	list(APPEND SRCS ${XAML_APP_DEF_SOURCE} ${XAML_CLATTER_SOURCE} ${COPIED_XAML_PER_PROJ_SOURCE} ${XAML_ASSET_FILES})
+	include_directories(${XAML_TEMPLATE_DIR})
+	set_source_files_properties(${XAML_ASSET_FILES} PROPERTIES VS_DEPLOYMENT_CONTENT 1)
+	set_source_files_properties(${XAML_ASSET_FILES} PROPERTIES VS_DEPLOYMENT_LOCATION "Assets")
+	set_source_files_properties(${XAML_APP_DEF_SOURCE} PROPERTIES VS_XAML_TYPE ApplicationDefinition)
+endif()
+# When template sources are unavoidable <<
+
+foreach(ONE_TARGET ${TARGET_NAME})
+	message([${ONE_TARGET}])
+
+	if(SINGLE_TARGET)
+		if(NOT IS_LIBRARY_PROJECT)
+			add_executable(${ONE_TARGET} ${EXE_TYPE} ${SRCS} ${HEADERS})
+		else()
+			add_library(${ONE_TARGET} ${LIB_OPTION} ${SRCS} ${HEADERS})
+		endif()
+	endif()
+
+	if(NOT IS_LIBRARY_PROJECT)
+		if(EXE_COPY_DIR)
+			# 2015/02/01 CMAKE_CONFIGURATION_TYPES may be empty.
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${EXE_COPY_DIR}")
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${EXE_COPY_DIR}")
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${EXE_COPY_DIR}")
+			foreach(CFGTYPE ${CMAKE_CONFIGURATION_TYPES})
+				string(TOUPPER ${CFGTYPE} UCFGTYPE)
+				set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${UCFGTYPE} "${EXE_COPY_DIR}")
+			endforeach(CFGTYPE)
+		endif()
+	else()
+		set(INHERITING_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ${OWN_HEADER_PATH} ${ADDITIONAL_HEADER_PATH})
+
+		foreach(DEPEND_TARGET ${INCLUDE_DEPENDENCY})
+			get_property(TARGET_INCLUDE_DIR TARGET ${DEPEND_TARGET} PROPERTY INCLUDE_DIRECTORIES)
+			list(APPEND INHERITING_INCLUDE_DIR ${TARGET_INCLUDE_DIR})
+		endforeach(DEPEND_TARGET)
+
+		list(REMOVE_DUPLICATES INHERITING_INCLUDE_DIR)
+		target_include_directories(${ONE_TARGET} PUBLIC ${INHERITING_INCLUDE_DIR})
+
+		if(VERBOSE_MODE)
+			message("Inheriting include directories ${INHERITING_INCLUDE_DIR}")
+		endif()
+	endif()
+
+	set(${ONE_TARGET}_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}" PARENT_SCOPE)
+
+	if(SUB_FOLDER)
+		if(VERBOSE_MODE)
+			message("Putting in folder ${SUB_FOLDER}")
+		endif()
+		set_property(TARGET ${ONE_TARGET} PROPERTY FOLDER ${SUB_FOLDER})
+	endif()
+
+	if(VERBOSE_MODE)
+		foreach(LINKLIB ${LIB_DEPENDENCY})
+			message(Lib=${LINKLIB})
+		endforeach(LINKLIB)
+	endif()
+	target_link_libraries(${ONE_TARGET} ${LIB_DEPENDENCY})
+
+	# We suffered enough from the shared stdc++
+	if(UNIX AND NOT APPLE AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+		target_link_libraries(${ONE_TARGET} pthread -static-libstdc++ -static-libgcc)
+	endif()
+
+	if(ADDITIONAL_HEADER_PATH)
+		if(VERBOSE_MODE)
+			message(Additional Include=${ADDITIONAL_HEADER_PATH})
+		endif()
+		include_directories(${ADDITIONAL_HEADER_PATH})
+	endif()
+endforeach(ONE_TARGET)
+
+if(DATA_FILE_LOCATION)
+	foreach(ONE_DATA_FILE_LOCATION ${DATA_FILE_LOCATION})
+		foreach(ONE_TARGET ${TARGET_NAME})
+			get_property(IS_MACOSX_BUNDLE TARGET ${ONE_TARGET} PROPERTY MACOSX_BUNDLE)
+
+			if(DATA_COPY_DIR)
+				set(DATA_DESTINATION ${DATA_COPY_DIR})
+			else()
+				if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+					if(NOT YS_ANDROID_ASSET_DIRECTORY)
+						MESSAGE(FATAL_ERROR "YS_ANDROID_ASSET_DIRECTORY not defined or empty.")
+					endif()
+					set(DATA_DESTINATION ${YS_ANDROID_ASSET_DIRECTORY})
+				elseif(NOT EXE_COPY_DIR)
+					if(APPLE AND IS_MACOSX_BUNDLE)
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>/../Resources")
+					elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>/Assets")
+					elseif(MSVC)
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>")
+					else()
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>")
+					endif()
+				else()
+					if(IS_MACOSX_BUNDLE)
+						set(DATA_DESTINATION "${EXE_COPY_DIR}/${ONE_TARGET}.app/Contents/Resources")
+					elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+						set(DATA_DESTINATION "${EXE_COPY_DIR}/Assets")
+					else()
+						set(DATA_DESTINATION "${EXE_COPY_DIR}")
+					endif()
+				endif()
+			endif()
+
+			# 2016/02/13 Use of generator-expression causes / be used in the DATA_DESTINATION
+			#            What's worse is it is not replaced with \\ by REGEX because it
+			#            is expanded at build time, not cmake time.
+			#if(MSVC)
+			#	string(REGEX REPLACE "/" "\\\\" WIN_ONE_DATA_FILE_LOCATION "${ONE_DATA_FILE_LOCATION}")
+			#	string(REGEX REPLACE "/" "\\\\" WIN_DATA_DESTINATION "${DATA_DESTINATION}")
+			#	add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+			#		COMMAND echo [File Copy]
+			#		COMMAND echo From: "${WIN_ONE_DATA_FILE_LOCATION}\\*"
+			#		COMMAND echo To:   "${WIN_DATA_DESTINATION}\\."
+			#		COMMAND xcopy "${WIN_ONE_DATA_FILE_LOCATION}\\*" "${WIN_DATA_DESTINATION}\\." /E /D /C /Y
+			#	)
+			#else()
+			#	add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+			#		COMMAND echo [File Copy]
+			#		COMMAND echo From: "${ONE_DATA_FILE_LOCATION}"
+			#		COMMAND echo To:   "${DATA_DESTINATION}"
+			#		COMMAND mkdir -p "${DATA_DESTINATION}"
+			#		COMMAND rsync -r "${ONE_DATA_FILE_LOCATION}/*" "${DATA_DESTINATION}"
+			#	)
+			#endif()
+
+			# "cmake -E copy_directory" does the job in any cmake-supporting platforms, but what if the command-line cmake is not installed like MacOSX App?
+			# 2016/02/13  Probably using ${CMAKE_COMMAND} is the solution.
+			set_property(TARGET ${ONE_TARGET} PROPERTY YS_DATA_COPY_DIR "${DATA_DESTINATION}")
+			add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+				COMMAND echo For:  ${ONE_TARGET}
+				COMMAND echo Copy
+				COMMAND echo From: ${ONE_DATA_FILE_LOCATION}
+				COMMAND echo To:   ${DATA_DESTINATION}
+				COMMAND "${CMAKE_COMMAND}" -E make_directory \"${DATA_DESTINATION}\"
+				COMMAND "${CMAKE_COMMAND}" -E copy_directory \"${ONE_DATA_FILE_LOCATION}\" \"${DATA_DESTINATION}\")
+
+		endforeach(ONE_TARGET)
+	endforeach(ONE_DATA_FILE_LOCATION)
+endif()
+
+#YSEND
+
+add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})

--- a/tests/batch/ysclass/YsPrintf/test.cpp
+++ b/tests/batch/ysclass/YsPrintf/test.cpp
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 //placeholder test (want to make sure this compiles and doesn't throw any runtime errors)
-YSRESULT Test(void)
+YSRESULT YsPrintf_TestPrintf(void)
 {
 	YsPrintf("%d\n", 10);
 
@@ -13,7 +13,7 @@ YSRESULT Test(void)
 int main(void)
 {
 	int nFail = 0;
-	if (YSOK != Test())
+	if (YSOK != YsPrintf_TestPrintf())
 	{
 		++nFail;
 	}

--- a/tests/batch/ysclass/YsPrintf/test.cpp
+++ b/tests/batch/ysclass/YsPrintf/test.cpp
@@ -1,0 +1,27 @@
+#include <ysdef.h>
+#include <ysprintf.h>
+#include <stdio.h>
+
+//placeholder test (want to make sure this compiles and doesn't throw any runtime errors)
+YSRESULT Test(void)
+{
+	YsPrintf("%d\n", 10);
+
+	return YSOK;
+}
+
+int main(void)
+{
+	int nFail = 0;
+	if (YSOK != Test())
+	{
+		++nFail;
+	}
+
+	printf("%d failed.\n", nFail);
+	if (0 < nFail)
+	{
+		return 1;
+	}
+	return 0;
+}

--- a/tests/batch/ysport/windows/CMakeLists.txt
+++ b/tests/batch/ysport/windows/CMakeLists.txt
@@ -1,0 +1,370 @@
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(BITNESS 64)
+else()
+	set(BITNESS 32)
+endif()
+
+set(TARGET_NAME "test_batch_ysport_windows")
+set(IS_LIBRARY_PROJECT 0)
+set(LIB_DEPENDENCY ysclass ysport ysglcpp)
+set(INCLUDE_DEPENDENCY "")
+set(OWN_HEADER_PATH .)
+set(ADDITIONAL_HEADER_PATH)
+set(SINGLE_TARGET 1)
+set(SUB_FOLDER "TESTS_BATCH/ysport")
+set(LIB_OPTION STATIC)
+set(VERBOSE_MODE 0)
+set(EXE_COPY_DIR "")
+set(WIN_SUBSYSTEM CONSOLE)
+set(EXE_TYPE "")                # Can be "" or MACOSX_BUNDLE
+set(EXCLUDE_IN_UNIVERSAL_WINDOWS 0) # Setting 1 will exclude the project in Universal Windows Platform
+
+list(APPEND YS_ALL_BATCH_TEST ${TARGET_NAME})
+set(YS_ALL_BATCH_TEST ${YS_ALL_BATCH_TEST} PARENT_SCOPE)
+
+
+set(DATA_FILE_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/data)
+# If DATA_FILE_LOCATION is set, files and directories under DATA_FILE_LOCATION will be copied to DATA_COPY_DIR.
+# For example, if DATA_FILE_LOCATION is ${CMAKE_SOURCE_DIR}/runtime, and the directory structure under this directory is:
+#    ${CMAKE_SOURCE_DIR}/runtime
+#      language
+#        ja.uitxt
+#        en.uitxt
+#      image1.png
+# then, the destination directory structure will look like:
+#    ${DATA_COPY_DIR}
+#      language
+#        ja.uitxt
+#        en.uitxt
+#      image1.png
+# It is not like directory "runtime" is copied under ${DATA_COPY_DIR}.
+
+
+
+
+#YSBEGIN "CMake Header" Ver 20170110
+# YS CMakeLists Template
+# Copyright (c) 2015 Soji Yamakawa.  All rights reserved.
+# http://www.ysflight.com
+# 
+# Redistribution and use in source and binary forms, with or without modification, 
+# are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, 
+#    this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, 
+#    this list of conditions and the following disclaimer in the documentation 
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 3.0.0)
+if("${CMAKE_CURRENT_SOURCE_DIR}" MATCHES "^${CMAKE_SOURCE_DIR}" AND
+   "${CMAKE_BINARY_DIR}" MATCHES "^${CMAKE_SOURCE_DIR}")
+	message(FATAL_ERROR "In-source build prohibited.\nClear cache and Start cmake from somewhere else.")
+	# First condition is to allow inclusion of the project from outside CMake project with
+	# explicit binary-directory specification.   eg. add_subdirectory from Android CMakeLists.txt
+endif()
+
+if(MSVC)
+	if(NOT WIN_SUBSYSTEM)
+		set(WIN_SUBSYSTEM CONSOLE)
+	endif()
+
+	if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+		if(EXCLUDE_IN_UNIVERSAL_WINDOWS EQUAL 1)
+			return()
+		endif()
+
+		add_definitions(-DYS_IS_UNIVERSAL_WINDOWS_APP)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZW")
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /ZW")
+	endif()
+
+	# I want to keep compatibility with older operating systems, but it's getting difficult.
+	# I have to comment out the following lines.
+	# if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	# 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:${WIN_SUBSYSTEM},5.02 /MACHINE:x64")
+	# else()
+	# 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:${WIN_SUBSYSTEM},5.01 /MACHINE:X86")
+	# endif()
+endif()
+
+if(NOT DEFINED TARGET_NAME)
+	message(FATAL_ERROR "TARGET_NAME not defined.")
+endif()
+if(NOT DEFINED IS_LIBRARY_PROJECT)
+	message(FATAL_ERROR "IS_LIBRARY_PROJECT not defined.")
+endif()
+if(NOT DEFINED SINGLE_TARGET)
+	message(FATAL_ERROR "SINGLE_TARGET not defined.")
+endif()
+
+# 2016/09/22 Learned a better way than specifying -std=c++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(MSVC)
+	# 2016/07/22
+	#  /MT flags should be set outside the public repository.  It is moved to the higher-level CMakeLists.txt
+elseif(APPLE)
+	# 2015/07/15
+	#   Sorry.  I pulled the plug.  All of my programs, including YS FLIGHT SIMULATOR, won't support 
+	#   OSX 10.6 after today.  Apple deliberately disabled C++11 features in the libraries that I need to make my 
+	#	programs compatible with OSX 10.6.
+	#
+	#	I know OSX 10.9 is evil for older models.  My 2008 MacBook Pro flies with OSX 10.6, but becoes
+	#	a sloth with OSX 10.9.  Apple used to be a challenger pursuing Microsoft, but it is now an empire
+	#	that Microsoft once was, and is doing everything that Microsoft did.  Apple inprison programmers
+	#	with Apple-only programming language called Swift (already doing with Objective-C though) and Apple-only
+	#	graphics toolkit called Metal, just as Microsoft did with C# and Direct3D.  Apple is making operating
+	#	system heavier, slower, and inefficient, just as Microsoft has been doing.  The same thing is going all 
+	#	around again.
+	#
+	#	OK, I warn you.  If you are investing your precious time for learning Swift and/or Metal, you are 
+	#	taking a very big gamble.  Apple will throw it away when they get bored of it.  Learning one programming 
+	#	language is not just understanding syntax.  You need to write considerable amount of code to learn the 
+	#	best practices.  So far, C and C++ have been with for more than 20 years.  Will Swift live that long?
+	#	Nobody knows.  I doubt it.  Swift is developed by a closed group.  Maybe one genius is in charge now.
+	#	But, when the genius leaves, it could cramble down.  C and C++ are developed by the top computer
+	#	scientists of the world.  To me, which is superior is obvious.
+	#
+	#	No user wants a new operating system.  Everyone wants their system to be cleaner, more stable, more 
+	#	secure, and more resource-efficient.  Neither Apple nor Microsoft gets it.  We continue to be forced
+	#	to throw away perfectly healthy hardware, and buy new over-spec hardware, which is inefficiently
+	#	operated by the wasteful operating systems.
+	#
+	#	Sad and outrageous.  But, that's what Apple do.  Apple takes C++11 hostage and forces programmers 
+	#	to drop support for older but still active-duty operating systems.
+	#
+	#	Mac is a good computer though.  I am happy with my 2011 MacMini.  I probably would be happy with
+	#	my 2008 MacBook Pro if I still can (practically) use it with OSX 10.6, or if 10.9 is as efficient 
+	#	as 10.6.
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9 -Wno-switch")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=10.9 -Wno-switch")
+elseif(UNIX)
+	# -Wl,--no-as-needed required for g++ 4.8.4 Confirmed unnecessary with 5.4.0
+	#  http://stackoverflow.com/questions/19463602/compiling-multithread-code-with-g
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,--no-as-needed")
+else()
+endif()
+
+if(IS_LIBRARY_PROJECT)
+	#set(YS_LIBRARY_LIST ${YS_LIBRARY_LIST} ${TARGET_NAME} PARENT_SCOPE)
+	# Modified as suggested in CMake performance tips.
+	list(APPEND YS_LIBRARY_LIST ${TARGET_NAME})
+	set(YS_LIBRARY_LIST ${YS_LIBRARY_LIST} PARENT_SCOPE)
+endif()
+
+#YSEND
+
+
+
+if(MSVC)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+elseif(APPLE)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+elseif(UNIX)
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+else()
+	set(platform_SRCS "")
+	set(platform_HEADERS "")
+endif()
+
+
+
+set(SRCS
+${platform_SRCS}
+test.cpp
+)
+
+set(HEADERS
+${platform_HEADERS}
+)
+
+
+
+#YSBEGIN "CMake Footer" Ver 20170110
+if(YS_CXX_FLAGS)
+	foreach(SRC ${SRCS})
+		if(${SRC} MATCHES .cpp$)
+			set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/${SRC} PROPERTIES COMPILE_FLAGS "${YS_CXX_FLAGS}")
+		endif()
+	endforeach(SRC)
+endif()
+
+# When template sources are unavoidable >>
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore" AND NOT IS_LIBRARY_PROJECT)
+	get_property(XAML_TEMPLATE_DIR TARGET fslazywindow PROPERTY FS_XAML_TEMPLATE_DIR)
+	get_property(XAML_ASSET_FILES TARGET fslazywindow PROPERTY FS_XAML_ASSET_FILES)
+	get_property(XAML_APP_DEF_SOURCE TARGET fslazywindow PROPERTY FS_XAML_APP_DEF_SOURCE)
+	get_property(XAML_CLATTER_SOURCE TARGET fslazywindow PROPERTY FS_XAML_CLATTER_SOURCE)
+	get_property(XAML_PER_PROJ_SOURCE TARGET fslazywindow PROPERTY FS_XAML_PER_PROJ_SOURCE)
+	foreach(SRC ${XAML_PER_PROJ_SOURCE})
+		file(COPY ${XAML_TEMPLATE_DIR}/${SRC} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+		list(APPEND COPIED_XAML_PER_PROJ_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/${SRC})
+	endforeach(SRC)
+	list(APPEND SRCS ${XAML_APP_DEF_SOURCE} ${XAML_CLATTER_SOURCE} ${COPIED_XAML_PER_PROJ_SOURCE} ${XAML_ASSET_FILES})
+	include_directories(${XAML_TEMPLATE_DIR})
+	set_source_files_properties(${XAML_ASSET_FILES} PROPERTIES VS_DEPLOYMENT_CONTENT 1)
+	set_source_files_properties(${XAML_ASSET_FILES} PROPERTIES VS_DEPLOYMENT_LOCATION "Assets")
+	set_source_files_properties(${XAML_APP_DEF_SOURCE} PROPERTIES VS_XAML_TYPE ApplicationDefinition)
+endif()
+# When template sources are unavoidable <<
+
+foreach(ONE_TARGET ${TARGET_NAME})
+	message([${ONE_TARGET}])
+
+	if(SINGLE_TARGET)
+		if(NOT IS_LIBRARY_PROJECT)
+			add_executable(${ONE_TARGET} ${EXE_TYPE} ${SRCS} ${HEADERS})
+		else()
+			add_library(${ONE_TARGET} ${LIB_OPTION} ${SRCS} ${HEADERS})
+		endif()
+	endif()
+
+	if(NOT IS_LIBRARY_PROJECT)
+		if(EXE_COPY_DIR)
+			# 2015/02/01 CMAKE_CONFIGURATION_TYPES may be empty.
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${EXE_COPY_DIR}")
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${EXE_COPY_DIR}")
+			set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${EXE_COPY_DIR}")
+			foreach(CFGTYPE ${CMAKE_CONFIGURATION_TYPES})
+				string(TOUPPER ${CFGTYPE} UCFGTYPE)
+				set_target_properties(${ONE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${UCFGTYPE} "${EXE_COPY_DIR}")
+			endforeach(CFGTYPE)
+		endif()
+	else()
+		set(INHERITING_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ${OWN_HEADER_PATH} ${ADDITIONAL_HEADER_PATH})
+
+		foreach(DEPEND_TARGET ${INCLUDE_DEPENDENCY})
+			get_property(TARGET_INCLUDE_DIR TARGET ${DEPEND_TARGET} PROPERTY INCLUDE_DIRECTORIES)
+			list(APPEND INHERITING_INCLUDE_DIR ${TARGET_INCLUDE_DIR})
+		endforeach(DEPEND_TARGET)
+
+		list(REMOVE_DUPLICATES INHERITING_INCLUDE_DIR)
+		target_include_directories(${ONE_TARGET} PUBLIC ${INHERITING_INCLUDE_DIR})
+
+		if(VERBOSE_MODE)
+			message("Inheriting include directories ${INHERITING_INCLUDE_DIR}")
+		endif()
+	endif()
+
+	set(${ONE_TARGET}_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}" PARENT_SCOPE)
+
+	if(SUB_FOLDER)
+		if(VERBOSE_MODE)
+			message("Putting in folder ${SUB_FOLDER}")
+		endif()
+		set_property(TARGET ${ONE_TARGET} PROPERTY FOLDER ${SUB_FOLDER})
+	endif()
+
+	if(VERBOSE_MODE)
+		foreach(LINKLIB ${LIB_DEPENDENCY})
+			message(Lib=${LINKLIB})
+		endforeach(LINKLIB)
+	endif()
+	target_link_libraries(${ONE_TARGET} ${LIB_DEPENDENCY})
+
+	# We suffered enough from the shared stdc++
+	if(UNIX AND NOT APPLE AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+		target_link_libraries(${ONE_TARGET} pthread -static-libstdc++ -static-libgcc)
+	endif()
+
+	if(ADDITIONAL_HEADER_PATH)
+		if(VERBOSE_MODE)
+			message(Additional Include=${ADDITIONAL_HEADER_PATH})
+		endif()
+		include_directories(${ADDITIONAL_HEADER_PATH})
+	endif()
+endforeach(ONE_TARGET)
+
+if(DATA_FILE_LOCATION)
+	foreach(ONE_DATA_FILE_LOCATION ${DATA_FILE_LOCATION})
+		foreach(ONE_TARGET ${TARGET_NAME})
+			get_property(IS_MACOSX_BUNDLE TARGET ${ONE_TARGET} PROPERTY MACOSX_BUNDLE)
+
+			if(DATA_COPY_DIR)
+				set(DATA_DESTINATION ${DATA_COPY_DIR})
+			else()
+				if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+					if(NOT YS_ANDROID_ASSET_DIRECTORY)
+						MESSAGE(FATAL_ERROR "YS_ANDROID_ASSET_DIRECTORY not defined or empty.")
+					endif()
+					set(DATA_DESTINATION ${YS_ANDROID_ASSET_DIRECTORY})
+				elseif(NOT EXE_COPY_DIR)
+					if(APPLE AND IS_MACOSX_BUNDLE)
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>/../Resources")
+					elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>/Assets")
+					elseif(MSVC)
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>")
+					else()
+						set(DATA_DESTINATION "$<TARGET_FILE_DIR:${ONE_TARGET}>")
+					endif()
+				else()
+					if(IS_MACOSX_BUNDLE)
+						set(DATA_DESTINATION "${EXE_COPY_DIR}/${ONE_TARGET}.app/Contents/Resources")
+					elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+						set(DATA_DESTINATION "${EXE_COPY_DIR}/Assets")
+					else()
+						set(DATA_DESTINATION "${EXE_COPY_DIR}")
+					endif()
+				endif()
+			endif()
+
+			# 2016/02/13 Use of generator-expression causes / be used in the DATA_DESTINATION
+			#            What's worse is it is not replaced with \\ by REGEX because it
+			#            is expanded at build time, not cmake time.
+			#if(MSVC)
+			#	string(REGEX REPLACE "/" "\\\\" WIN_ONE_DATA_FILE_LOCATION "${ONE_DATA_FILE_LOCATION}")
+			#	string(REGEX REPLACE "/" "\\\\" WIN_DATA_DESTINATION "${DATA_DESTINATION}")
+			#	add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+			#		COMMAND echo [File Copy]
+			#		COMMAND echo From: "${WIN_ONE_DATA_FILE_LOCATION}\\*"
+			#		COMMAND echo To:   "${WIN_DATA_DESTINATION}\\."
+			#		COMMAND xcopy "${WIN_ONE_DATA_FILE_LOCATION}\\*" "${WIN_DATA_DESTINATION}\\." /E /D /C /Y
+			#	)
+			#else()
+			#	add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+			#		COMMAND echo [File Copy]
+			#		COMMAND echo From: "${ONE_DATA_FILE_LOCATION}"
+			#		COMMAND echo To:   "${DATA_DESTINATION}"
+			#		COMMAND mkdir -p "${DATA_DESTINATION}"
+			#		COMMAND rsync -r "${ONE_DATA_FILE_LOCATION}/*" "${DATA_DESTINATION}"
+			#	)
+			#endif()
+
+			# "cmake -E copy_directory" does the job in any cmake-supporting platforms, but what if the command-line cmake is not installed like MacOSX App?
+			# 2016/02/13  Probably using ${CMAKE_COMMAND} is the solution.
+			set_property(TARGET ${ONE_TARGET} PROPERTY YS_DATA_COPY_DIR "${DATA_DESTINATION}")
+			add_custom_command(TARGET ${ONE_TARGET} POST_BUILD 
+				COMMAND echo For:  ${ONE_TARGET}
+				COMMAND echo Copy
+				COMMAND echo From: ${ONE_DATA_FILE_LOCATION}
+				COMMAND echo To:   ${DATA_DESTINATION}
+				COMMAND "${CMAKE_COMMAND}" -E make_directory \"${DATA_DESTINATION}\"
+				COMMAND "${CMAKE_COMMAND}" -E copy_directory \"${ONE_DATA_FILE_LOCATION}\" \"${DATA_DESTINATION}\")
+
+		endforeach(ONE_TARGET)
+	endforeach(ONE_DATA_FILE_LOCATION)
+endif()
+
+#YSEND
+
+add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})

--- a/tests/batch/ysport/windows/data/filename.txt
+++ b/tests/batch/ysport/windows/data/filename.txt
@@ -1,0 +1,1 @@
+test data here!

--- a/tests/batch/ysport/windows/test.cpp
+++ b/tests/batch/ysport/windows/test.cpp
@@ -1,0 +1,57 @@
+#include <ysdef.h>
+#include <ysfileio.h>
+
+//test scenario: test Fopen with "r" permissions
+YSRESULT YsFileIO_Fopen_Test(char mode[])
+{
+	YsWString str;
+	str.SetUTF8String("filename.txt");
+	FILE* file = YsFileIO::Fopen(str, mode);
+
+	if (file == NULL)
+	{
+		return YSERR;
+	}
+	return YSOK;
+}
+
+int main(void)
+{
+	int nFail = 0;
+	if (YSOK != YsFileIO_Fopen_Test("r"))
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFileIO_Fopen_Test("w"))
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFileIO_Fopen_Test("a"))
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFileIO_Fopen_Test("r+"))
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFileIO_Fopen_Test("w+"))
+	{
+		++nFail;
+	}
+
+	if (YSOK != YsFileIO_Fopen_Test("a+"))
+	{
+		++nFail;
+	}
+
+	printf("%d failed.\n", nFail);
+	if (0 < nFail)
+	{
+		return 1;
+	}
+	return 0;
+}


### PR DESCRIPTION
Fixes the following (and adds tests to verify that the fixes don't cause memory issues or other runtime errors):

D:\a\YSCE\YSCE\public\src\ysbitmap\src\ysbitmap.cpp(119,11): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\YSCE\YSCE\ci_windows\public\ysbitmap\src\ysbitmap.vcxproj]

D:\a\YSCE\YSCE\public\src\ysclass\src\ysfilename.cpp(179,2): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\YSCE\YSCE\ci_windows\public\ysclass\src\ysclass.vcxproj]

D:\a\YSCE\YSCE\public\src\ysclass\src\ysfilename.cpp(221,2): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\YSCE\YSCE\ci_windows\public\ysclass\src\ysclass.vcxproj]

D:\a\YSCE\YSCE\public\src\ysbitmap\src\yspngenc.cpp(1679,3): warning C4996: 'strncpy': This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\YSCE\YSCE\ci_windows\public\ysbitmap\src\ysbitmap.vcxproj]

D:\a\YSCE\YSCE\public\src\ysclass\src\ysprintf.cpp(61,4): warning C4996: 'vsprintf': This function or variable may be unsafe. Consider using vsprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\YSCE\YSCE\ci_windows\public\ysclass\src\ysclass.vcxproj]

D:\a\YSCE\YSCE\public\src\ysport\src\windows\yswin32fileio.cpp(90,9): warning C4996: '_wfopen': This function or variable may be unsafe. Consider using _wfopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\YSCE\YSCE\ci_windows\public\ysport\src\ysport.vcxproj]

D:\a\YSCE\YSCE\public\src\ysclass\src\ysfilename.cpp(277,3): warning C4996: 'strcat': This function or variable may be unsafe. Consider using strcat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\YSCE\YSCE\ci_windows\public\ysclass\src\ysclass.vcxproj]