### PR TITLE
add YsNot function

### DIFF
--- a/src/ysclass/src/ysdef.h
+++ b/src/ysclass/src/ysdef.h
@@ -82,6 +82,15 @@ inline YSBOOL YsXor(YSBOOL a,YSBOOL b)
 	return YSFALSE;
 }
 
+inline YSBOOL YsNot(YSBOOL a)
+{
+	if (a == YSTRUE)
+	{
+		return YSFALSE;
+	}
+	return YSTRUE;
+}
+
 #endif
 
 


### PR DESCRIPTION
adds a `YsNot` function (logical NOT for YSBOOL type), which is used by the weapon jettison logic