### PR TITLE
Improved subsecond timer for nowindow

### DIFF
--- a/src/fssimplewindow/src/nownd/fssimplenowindow.cpp
+++ b/src/fssimplewindow/src/nownd/fssimplenowindow.cpp
@@ -30,6 +30,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <chrono>
 
 #ifdef _WIN32
 	#include <io.h>
@@ -492,7 +493,9 @@ long long int FsPassedTime(void)
 
 long long int FsSubSecondTimer(void)
 {
-	return time(NULL)*1000;
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+    ).count();
 }
 
 int FsInkey(void)


### PR DESCRIPTION
Changed the subsecond timer to use chrono instead of time(). Results in a huge CPU saving for console servers. Had been using 97% CPU on my server, and 15% when benchmarked on my PC.
On the PC it has dropped to 1-2% max. 
