### PR TITLE
Fix crash on exit

### DIFF
--- a/src/ysglcpp/src/gl1/ysglbuffermanager_gl1.cpp
+++ b/src/ysglcpp/src/gl1/ysglbuffermanager_gl1.cpp
@@ -56,6 +56,10 @@ void YsGLBufferManager::ActualBuffer::PrepareDisplayList(YSSIZE_T nList)
 }
 /* static */ void YsGLBufferManager::Unit::Delete(YsGLBufferManager::ActualBuffer *ptr)
 {
+	if(nullptr==ptr)
+	{
+		return;
+	}
 	for(auto &buf : ptr->bufSet)
 	{
 		if(GL_TRUE==glIsList(buf.listIdent))

--- a/src/ysglcpp/src/gl2/ysglbuffermanager_gl2.cpp
+++ b/src/ysglcpp/src/gl2/ysglbuffermanager_gl2.cpp
@@ -68,6 +68,10 @@ void YsGLBufferManager::ActualBuffer::PrepareVbo(YSSIZE_T nVbo)
 }
 /* static */ void YsGLBufferManager::Unit::Delete(YsGLBufferManager::ActualBuffer *ptr)
 {
+	if(nullptr==ptr)
+	{
+		return;
+	}
 	for(auto &buf : ptr->bufSet)
 	{
 		if(GL_TRUE==glIsBuffer(buf.vboIdent))

--- a/src/ysglcpp/src/ysglbuffermanager.cpp
+++ b/src/ysglcpp/src/ysglbuffermanager.cpp
@@ -108,7 +108,11 @@ void YsGLBufferManager::Delete(Handle hd)
 {
 	if(nullptr!=hd)
 	{
-		bufferArray[hd]->CleanUp();
+		auto *ptr=bufferArray[hd];
+		if(nullptr!=ptr)
+		{
+			ptr->CleanUp();
+		}
 		bufferArray.Delete(hd);
 	}
 }


### PR DESCRIPTION
Null guard in YsGLBufferManager::Unit::Delete() and YsGLBufferManager::Delete() to prevent crash during static destruction on macOS.